### PR TITLE
ソート順を正しくした 本番環境でカテゴリーID順になぜか並んでた

### DIFF
--- a/api/app/UseCase/GetQuestions.php
+++ b/api/app/UseCase/GetQuestions.php
@@ -13,7 +13,7 @@ class GetQuestions {
      * 設問取得
      */
    public function invoke(){
-     $questons = Question::from('questions as q')->leftJoin('categories as c', 'q.category_id', '=', 'c.id')->select(['q.id', 'c.category_name','q.question_contents','is_reversal'])->get();
+     $questons = Question::from('questions as q')->leftJoin('categories as c', 'q.category_id', '=', 'c.id')->select(['q.id', 'c.category_name','q.question_contents','is_reversal'])->orderBy('q.id', 'asc')->get();
     
      return $questons;
    }

--- a/front/components/question.vue
+++ b/front/components/question.vue
@@ -28,7 +28,7 @@ const isHideDivider = computed(() => {
         {{ question.question_contents }}
       </p>
     </div>
-    <div class="choices-container d-flex justify-space-around">
+    <div class="choices-container d-flex justify-space-around mb-5">
       <template v-for="choice in choices" :key="choice.value" class="">
         <div class="d-flex flex-column justify-space-between input-container">
           <input


### PR DESCRIPTION
#したこと
- ソート順を正しくした 明示的に設問id順番にした
- デザインでモーダル調整